### PR TITLE
[IMP] Addon om_account_asset

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -58,3 +58,5 @@ merged_models = {
     # odoo
     # OCA/...
 }
+
+renamed_modules.update({"account_asset_management": "om_account_asset"})


### PR DESCRIPTION
Se renombra addon account_asset_management a om_account_asset. om_account_asset es el que vamos a utilizar para sustituir al estandar que dejo de existir (account_asset)